### PR TITLE
Allow to save results with fixed file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,22 @@ Wait for job completion and stream logs'
 
 Marks action failed in any test result is `fail`. Requires `wait_for_job` set to `true`
 
-## 'save_result_as_artifact'
+## `save_result_as_artifact`
 
 Saves JUNIT file with test results. The file name is `test-resutls-<lava job ID>.xml`.
 The file is saved to the top directory of the workflow artifacts.
+
+## `save_job_details`
+
+Saves LAVA job details retrieved from API as JSON file. Note that the file contains
+full rendered job definition. It may contain sensitive data (like passwords).
+Defaults to `false`
+
+## `result_file_name`
+
+The file name of the results pulled from LAVA API after the job is completed.
+It can be used to overwrite the results when re-running the action in github workflow.
+Defaults to `test-results-<jobID>`
 
 ## Example usage
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,10 @@ inputs:
   save_job_details:
     description: 'Save job details as JSON file'
     default: false
+  result_file_name:
+    description: 'File name in which the test results will be stored. Defaults to test-results-<jobID>.
+      If the file with the same name is already stored as workflow artifact it will be overwritten.
+      This option is useful for keeping clean results in case of re-running test jobs.'
 
 runs:
   using: 'node20'


### PR DESCRIPTION
This patch adds option to pass file name to the action. It will allow to overwrite results from failed test jobs if the action is restarted.