### PR TITLE
Add flag to fail action on Incomplete LAVA job

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Wait for job completion and stream logs'
 
 Marks action failed in any test result is `fail`. Requires `wait_for_job` set to `true`
 
+## `fail_action_on_incomplete`
+
+Marks action failed in case test jobs ends as `Incomplete` or is `Canceled`
+
 ## `save_result_as_artifact`
 
 Saves JUNIT file with test results. The file name is `test-resutls-<lava job ID>.xml`.

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,9 @@ inputs:
   fail_action_on_failure:
     description: 'Marks action failed in any test result is "fail". Requires wait_for_job set to "true"'
     default: true
+  fail_action_on_incomplete:
+    description: 'Marks action failed in case test jobs ends as Incomplete or is Canceled'
+    default: true
   save_result_as_artifact:
     description: 'Save test results as JUNIT XML file'
     default: false


### PR DESCRIPTION
When LAVA job ends as Incomplete or Canceled the action is marked as failed by default. This patch allows to avoid that. It's useful when it's expected that some other action is following in the workflow (for example result reporting).